### PR TITLE
Split licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -27,30 +27,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-`Homogeneous.Keys` class was directly copied from `purescript-record-extra`
-which is licensed as follows:
-
-The MIT License (MIT)
-
-Copyright (c) 2017 Justin Woo, Adam Saleh
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.

--- a/LICENSE_THIRDPARTY
+++ b/LICENSE_THIRDPARTY
@@ -1,0 +1,24 @@
+`Homogeneous.Keys` class was directly copied from `purescript-record-extra`
+which is licensed as follows:
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Justin Woo, Adam Saleh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This PR splits the LICENSE file out into two files:
- LICENSE for the `homogeneous` license
- LICENSE_THIRDPARTY for the notice of adaptation from `record-extra`

`licensee` will now correctly detect the contents of the LICENSE file:

```
λ licensee detect LICENSE
License:        BSD-3-Clause
Matched files:  LICENSE
LICENSE:
  Content hash:  a961b19cc6921d510e29a13b0ba1a826fcffe41c
  Attribution:   Copyright (c) 2020, Tomasz Rybarczyk (aka paluh)
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       BSD-3-Clause
```

### Motivation

`homogeneous` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have this license issue addressed in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.